### PR TITLE
improved parsing

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 
-[mypy-pytest,nox.*,_pytest.*,sphinx.*]
+[mypy-pytest,nox.*,_pytest.*,sphinx.*,pygments.*]
 ignore_missing_imports = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,3 +109,11 @@ def coverage(session: Session) -> None:
     install_constrained_version(session, "coverage[toml]", "codecov")
     session.run("coverage", "xml", "--fail-under=0")
     session.run("codecov", *session.posargs)
+
+
+@nox.session(python="3.8")
+def black(session: Session) -> None:
+    """Format code with Black."""
+    args = session.posargs or locations
+    install_constrained_version(session, "black")
+    session.run("black", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ source = ["sphinxawesome.sampdirective"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 93
+fail_under = 100
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/test-root/index.rst
+++ b/tests/test-root/index.rst
@@ -23,3 +23,11 @@ Just a normal paragraph.
 .. samp::
 
    $HOME should not be highlighted
+
+.. samp::
+
+   # alternate prompt character
+
+.. samp::
+
+   ~ alternate prompt character

--- a/tests/test_sphinxawesome_sampdirective.py
+++ b/tests/test_sphinxawesome_sampdirective.py
@@ -50,7 +50,7 @@ def test_finds_samp_directives(
 
     et = etree_parse(app.outdir / "index.xml")
     blocks = et.findall("./section/literal_block")
-    assert len(blocks) == 5
+    assert len(blocks) == 7
 
 
 @pytest.mark.sphinx(
@@ -130,3 +130,24 @@ def test_parses_samp_directive_with_prompt_char_in_variable(app: Sphinx) -> None
     #  fourth block should not have "gp", because it's not a prompt
     test = blocks[4].findall("./inline")
     assert len(test) == 0
+
+
+@pytest.mark.sphinx(
+    "xml", confoverrides={"extensions": ["sphinxawesome.sampdirective"]}
+)
+def test_recognizes_alternate_prompt_characters(app: Sphinx) -> None:
+    """It parses `#` and `~ ` as a prompt characters."""
+    app.builder.build_all()
+
+    et = etree_parse(app.outdir / "index.xml")
+    blocks = et.findall("./section/literal_block")
+
+    #  fifth block has a "gp" class for the '#' prompt character
+    test = blocks[5].findall("./inline")
+    assert len(test) == 1
+    assert test[0].get("classes") == "gp"
+
+    # sixth block has a "gp" class for the '~' prompt character
+    test = blocks[6].findall("./inline")
+    assert len(test) == 1
+    assert test[0].get("classes") == "gp"

--- a/tests/test_sphinxawesome_sampdirective.py
+++ b/tests/test_sphinxawesome_sampdirective.py
@@ -100,7 +100,6 @@ def test_parses_samp_with_one_prompt(app: Sphinx) -> None:
     assert test[0].get("classes") == "gp"
 
 
-@pytest.mark.xfail(reason="Currently a bug.")
 @pytest.mark.sphinx(
     "xml", confoverrides={"extensions": ["sphinxawesome.sampdirective"]}
 )
@@ -118,7 +117,6 @@ def test_parses_samp_with_two_prompts(app: Sphinx) -> None:
     assert test[1].get("classes") == "gp"
 
 
-@pytest.mark.xfail(reason="Currently a bug.")
 @pytest.mark.sphinx(
     "xml", confoverrides={"extensions": ["sphinxawesome.sampdirective"]}
 )
@@ -130,5 +128,5 @@ def test_parses_samp_directive_with_prompt_char_in_variable(app: Sphinx) -> None
     blocks = et.findall("./section/literal_block")
 
     #  fourth block should not have "gp", because it's not a prompt
-    test = blocks[3].findall("./inline")
+    test = blocks[4].findall("./inline")
     assert len(test) == 0

--- a/tests/test_sphinxawesome_sampdirective.py
+++ b/tests/test_sphinxawesome_sampdirective.py
@@ -40,13 +40,21 @@ def test_returns_warning_without_extension(
 @pytest.mark.sphinx(
     "xml", confoverrides={"extensions": ["sphinxawesome.sampdirective"]}
 )
-def test_finds_samp_directives(
+def test_does_not_return_warning_with_extension(
     app: Sphinx, status: StringIO, warning: StringIO
 ) -> None:
     """It does not return a warning if the extension is enabled."""
     app.builder.build_all()
 
     assert "" in warning.getvalue()
+
+
+@pytest.mark.sphinx(
+    "xml", confoverrides={"extensions": ["sphinxawesome.sampdirective"]}
+)
+def test_finds_samp_directives(app: Sphinx) -> None:
+    """It finds all samp directives."""
+    app.builder.build_all()
 
     et = etree_parse(app.outdir / "index.xml")
     blocks = et.findall("./section/literal_block")


### PR DESCRIPTION
All the different cases are now handled. Prompt at the beginning, placeholder variables, multiple lines, prompt character inside a variable... 

Switching from the custom pattern matching I copied from the `samp` role to a lexer from pygments also makes the code much easier to understand. 